### PR TITLE
chore: automatically derive version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
 build-backend = "hatchling.build"
-requires = [ "hatchling" ]
+requires = [ "hatch-vcs", "hatchling" ]
 
 [project]
 name = "interscale"
-version = "0.0.1"
 description = "Multi-scale cell interaction model for spatial transcriptomics data."
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -16,6 +15,7 @@ authors = [
   { name = "Sara Jimenez" },
 ]
 requires-python = ">=3.11"
+dynamic = [ "version" ]
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
@@ -95,6 +95,7 @@ envs.hatch-test.matrix = [
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { key = "UV_PRERELEASE", value = "allow", if = [ "pre" ] },
 ]
+version.source = "vcs"
 
 [tool.uv]
 # fix build deps when building from source

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ authors = [
   { name = "Sara Jimenez" },
 ]
 requires-python = ">=3.11"
-dynamic = [ "version" ]
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
@@ -23,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
 ]
+dynamic = [ "version" ]
 dependencies = [
   "anndata",
   "fast-array-utils[accel]",


### PR DESCRIPTION
The version pushed to PyPI is `0.0.1`, since the `version` metadata on the `main` branch (and the 0.2.0 tag) is static (`version = "0.0.1"`)

This PR switches to `hatch-vcs` which simply derives the version from the Git tag, i.e. when you create the next release, the tag name you define will be the version.

## alternatives

you could manage the `version` metadata manually and update it before a release